### PR TITLE
Fix wrong string id for translation

### DIFF
--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -12,5 +12,5 @@
   <string id="30501">Visa undertexter</string>
   <string id="30502">Gruppera program i A-Ö efter första bokstav</string>
   <string id="30503">Antal program per sida</string>
-  <string id="30503">Dölj teckentolkade program</string>
+  <string id="30504">Dölj teckentolkade program</string>
 </strings>


### PR DESCRIPTION
Swedish translation had an ID error.
