### PR TITLE
[Review] Add option to only playback streams in standard definition (SD)

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -13,4 +13,7 @@
   <string id="30502">Group programs in A-Ö by first character</string>
   <string id="30503">Number of programs per page</string>
   <string id="30504">Hide sign language interpreted programs</string>
+  <string id="30505">Don't use avc1.77.30 streams</string>
+  <string id="40001">General</string>
+  <string id="40002">Advanced</string>
 </strings>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -13,4 +13,7 @@
   <string id="30502">Gruppera program i A-Ö efter första bokstav</string>
   <string id="30503">Antal program per sida</string>
   <string id="30504">Dölj teckentolkade program</string>
+  <string id="30505">Använd inte avc1.77.30 videoströmmar</string>
+  <string id="40001">Allmänt</string>
+  <string id="40002">Avancerat</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+  <category label="40001">
     <setting id="diritems" type="slider" label="30503" default="20" range="20,10,100" option="int" />
     <setting id="alpha" type="bool" label="30502" default="false" />
     <setting id="hidesignlanguage" type="bool" label="30504" default="false" />
     <setting id="showsubtitles" type="bool" label="30501" default="false" />
     <setting id="debug" type="bool" label="30500" default="false" />
+  </category>
+  <category label="40002">
+    <setting id="hlsstrip" type="bool" label="30505" default="false" />
+  </category>
 </settings>


### PR DESCRIPTION
Needs review.

This option was added as a hack for ATV2 which has problems playing streams encoded using h264 with the avc1.77.30 profile.
The plugin will only playback streams with a maximum resolution of 1024x576 if the option is enabled.

This one includes pull 33 (!).
