### PR TITLE
Add "PSL", mp4 support, and refactoring

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -6,6 +6,7 @@
   <string id="30003">Latest programs</string>  
   <string id="30004">Latest news broadcast</string>
   <string id="30005">Recommended</string>
+  <string id="30006">PSL</string>
   <string id="30100">This program is only available at www.svtplay.se</string>
   <string id="30101">More programs...</string>
   <string id="30500">Debug</string>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -6,6 +6,7 @@
   <string id="30003">Senaste program</string>
   <string id="30004">Senaste nyhetsprogram</string>
   <string id="30005">Rekommenderat</string>
+  <string id="30006">PSL</string>
   <string id="30100">Detta program är endast tillgängligt på www.svtplay.se</string>
   <string id="30101">Fler program...</string>
   <string id="30500">Debug</string>


### PR DESCRIPTION
The music show "PSL" did not show up in the other listings, added it as separate category.
The show consists of "clips" only, which needs a slightly different logic than the others.

Old "clips" are only available in MP4 format. Added support for this in the video parser.

Refactored the code since there were a lot of duplicated code, and to make it easier to incorporate "PSL".

PR mania, I have a hard time letting go...
