### PR TITLE
[Review][Do not merge]Add search feature to the plugin

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -6,9 +6,14 @@
   <string id="30003">Latest programs</string>  
   <string id="30004">Latest news broadcast</string>
   <string id="30005">Recommended</string>
-  <string id="30006">PSL</string>
+  <string id="30006">Search</string>
   <string id="30100">This program is only available at www.svtplay.se</string>
-  <string id="30101">More programs...</string>
+  <string id="30101">Show more...</string>
+  <string id="30102">Search for:</string>
+  <string id="30103">The search returned no results</string>
+  <string id="30104">Programs</string>
+  <string id="30105">Episodes</string>
+  <string id="30106">Clips</string>
   <string id="30500">Debug</string>
   <string id="30501">Show subtitles</string>
   <string id="30502">Group programs in A-Ö by first character</string>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -6,9 +6,14 @@
   <string id="30003">Senaste program</string>
   <string id="30004">Senaste nyhetsprogram</string>
   <string id="30005">Rekommenderat</string>
-  <string id="30006">PSL</string>
+  <string id="30006">Sök</string>
   <string id="30100">Detta program är endast tillgängligt på www.svtplay.se</string>
-  <string id="30101">Fler program...</string>
+  <string id="30101">Visa fler...</string>
+  <string id="30102">Sök efter:</string>
+  <string id="30103">Sökningen gav inga räffar</string>
+  <string id="30104">Program</string>
+  <string id="30105">Avsnitt</string>
+  <string id="30106">Klipp</string>
   <string id="30500">Debug</string>
   <string id="30501">Visa undertexter</string>
   <string id="30502">Gruppera program i A-Ö efter första bokstav</string>


### PR DESCRIPTION
This commit adds the ability to search for an item on SVT Play.
Search results are grouped after type (like on the web page) so that paging can be supported.
This commit also introduces some refactoring for the sake of removing code duplication.
Finally, "PSL" was removed since it can now be found by searching for it.

Do not merge this PR. If it is OK then I will reformat the plugin to adhere to PEP8 styling guidelines and publish a new PR with this PR plus formatting change included.

Created new since the squashing messed up the other PR. Sorry for the confusion.
