### PR TITLE
Add full parsing to program pages

### DIFF
--- a/default.py
+++ b/default.py
@@ -22,11 +22,11 @@ MODE_CATEGORY = "ti"
 MODE_LETTER = "letter"
 MODE_RECOMMENDED = "rp"
 MODE_SEARCH = "search"
-MODE_SEARCH_TITLES = "search_titles"
-MODE_SEARCH_EPISODES = "search_episodes"
-MODE_SEARCH_CLIPS = "search_clips"
 MODE_BESTOF_CATEGORIES = "bestofcategories"
 MODE_BESTOF_CATEGORY = "bestofcategory"
+MODE_VIEW_TITLES = "view_titles"
+MODE_VIEW_EPISODES = "view_episodes"
+MODE_VIEW_CLIPS = "view_clips"
 
 BASE_URL = "http://www.svtplay.se"
 SWF_URL = "http://www.svtplay.se/public/swf/video/svtplayer-2012.51.swf" 
@@ -41,6 +41,12 @@ URL_TO_SEARCH = "/sok?q="
 VIDEO_PATH_RE = "/(klipp|video|live)/\d+"
 VIDEO_PATH_SUFFIX = "?type=embed"
 
+TAB_TITLES      = "titles"
+TAB_EPISODES    = "episodes"
+TAB_CLIPS       = "clips"
+TAB_NEWS        = "news"
+TAB_RECOMMENDED = "recommended"
+
 MAX_NUM_GRID_ITEMS = 12
 CURR_DIR_ITEMS = 0
 
@@ -52,17 +58,33 @@ localize = settings.getLocalizedString
 common = CommonFunctions
 common.plugin = "SVT Play 3"
 
+# Get and set settings
+common.dbg = False
 if settings.getSetting('debug') == "true":
   common.dbg = True
-else:
-  common.dbg = False
 
+HLS_STRIP = False
 if settings.getSetting("hlsstrip") == "true":
     HLS_STRIP = True
-else:
-    HLS_STRIP = False
+
+FULL_PROGRAM_PARSE = False
+if settings.getSetting("fullparse") == "true":
+  FULL_PROGRAM_PARSE = True
+
+HIDE_SIGN_LANGUAGE = False
+if settings.getSetting("hidesignlanguage") == "true":
+  HIDE_SIGN_LANGUAGE = True
+
+SHOW_SUBTITLES = False
+if settings.getSetting("showsubtitles") == "true":
+  SHOW_SUBTITLES = True
+
+USE_ALPHA_CATEGORIES = False
+if settings.getSetting("alpha") == "true":
+  USE_ALPHA_CATEGORIES = True
 
 MAX_DIR_ITEMS = int(float(settings.getSetting("diritems")))
+
 
 def viewStart():
 
@@ -190,7 +212,10 @@ def viewCategory(url,page,index):
   createDirectory(url,page,index,MODE_CATEGORY,MODE_PROGRAM)
 
 def viewProgram(url,page,index):
-  createDirectory(url,page,index,MODE_PROGRAM,MODE_VIDEO)
+  if FULL_PROGRAM_PARSE:
+    createTabIndex(url)
+  else:
+    createDirectory(url,page,index,MODE_PROGRAM,MODE_VIDEO)
 
 def viewSearch():
 
@@ -208,51 +233,54 @@ def viewSearch():
   keyword = re.sub(r" ","+",keyword) 
 
   url = URL_TO_SEARCH + keyword
+  
+  createTabIndex(url)
+
+def createTabIndex(url):
+  """
+  Creates a directory item for each available tab; Klipp, Hela program, Programtitlar
+  """
   html = getPage(BASE_URL + url)
   foundTab = False
  
-  # Try fetching the "titles" tab. If it exists; create link to result directory   
-  try:
-    common.parseDOM(html, "div", attrs = { "data-tabname": "titles" })[0]
-    foundTab = True
-  except:
+  # Search for the "titles" tab. If it exists; create link to result directory   
+  foundTab = tabExists(url,TAB_TITLES)
+  if foundTab:
+    addDirectoryItem(localize(30104), { 
+                    "mode": MODE_VIEW_TITLES,
+                    "url": url,
+                    "page": 1,
+                    "index": 0 })
+  else:
     # Do nothing
     common.log("No titles found")
-  else:
-    addDirectoryItem(localize(30104), { 
-                    "mode": MODE_SEARCH_TITLES,
+
+
+  # Search for the "episodes" tab. If it exists; create link to result directory   
+  foundTab = tabExists(url,TAB_EPISODES)
+  if foundTab:
+    addDirectoryItem(localize(30105), { 
+                    "mode": MODE_VIEW_EPISODES,
                     "url": url,
                     "page": 1,
                     "index": 0 })
-
-  # Try fetching the "episodes" tab. If it exists; create link to result directory   
-  try:
-    common.parseDOM(html, "div", attrs = { "data-tabname": "episodes" })[0]
-    foundTab = True
-  except:
+  else:
     # Do nothing
     common.log("No episodes found")
-  else:
-    addDirectoryItem(localize(30105), { 
-                    "mode": MODE_SEARCH_EPISODES,
+
+
+  # Search for the "clips" tab. If it exists; create link to result directory   
+  foundTab = tabExists(url,TAB_CLIPS)
+  if foundTab:
+    addDirectoryItem(localize(30106), { 
+                    "mode": MODE_VIEW_CLIPS,
                     "url": url,
                     "page": 1,
                     "index": 0 })
-
-  # Try fetching the "clips" tab. If it exists; create link to result directory   
-  try:
-    common.parseDOM(html, "div", attrs = { "data-tabname": "clips" })[0]
-    foundTab = True
-  except:
+  else:
     # Do nothing 
     common.log("No clips found")
-  else:
-    addDirectoryItem(localize(30106), { 
-                    "mode": MODE_SEARCH_CLIPS,
-                    "url": url,
-                    "page": 1,
-                    "index": 0 })
- 
+
   if not foundTab:
     # Raise dialog with a "No results found" message
     common.log("No search result") 
@@ -261,7 +289,26 @@ def viewSearch():
     viewSearch()
     return
 
-def viewSearchResults(url,mode,page,index):
+def tabExists(url,tabname):
+  """
+  Check if a specific tab exists in the DOM.
+  """
+  html = getPage(BASE_URL + url)
+  return elementExists(html,"div",{ "data-tabname": tabname})
+
+def elementExists(html,etype,attrs):
+  """
+  Check if a specific element exists in the DOM.
+
+  Returns True if the element exists and False if not.
+  """
+
+  htmlelement = common.parseDOM(html,etype, attrs = attrs)
+
+  return len(htmlelement) > 0
+
+
+def viewPageResults(url,mode,page,index):
   """
   Creates a directory for the search results from
   the tab specified by the mode parameter.
@@ -269,11 +316,11 @@ def viewSearchResults(url,mode,page,index):
   common.log("url: " + url + " mode: " + mode)
   dirtype = None
 
-  if MODE_SEARCH_TITLES == mode:
+  if MODE_VIEW_TITLES == mode:
     dirtype = MODE_PROGRAM
-  elif MODE_SEARCH_EPISODES == mode:
+  elif MODE_VIEW_EPISODES == mode:
     dirtype = MODE_VIDEO
-  elif MODE_SEARCH_CLIPS == mode:
+  elif MODE_VIEW_CLIPS == mode:
     dirtype = MODE_VIDEO
   else:
     common.log("Undefined mode")
@@ -318,15 +365,21 @@ def createDirectory(url,page,index,callertype,dirtype):
   if not url.startswith("/"):
     url = "/" + url
 
-  tabname = "episodes"
+  tabname = TAB_EPISODES
   if MODE_RECOMMENDED == callertype:
-    tabname = "recommended"
+    tabname = TAB_RECOMMENDED
   elif MODE_LATEST_NEWS == callertype:
-    tabname = "news"
-  elif MODE_SEARCH_CLIPS == callertype:
-    tabname = "clips"
-  elif MODE_CATEGORY == callertype or MODE_SEARCH_TITLES == callertype:
-    tabname = "titles"
+    tabname = TAB_NEWS
+  elif MODE_VIEW_CLIPS == callertype:
+    tabname = TAB_CLIPS
+  elif MODE_CATEGORY == callertype or MODE_VIEW_TITLES == callertype:
+    tabname = TAB_TITLES
+
+  if not tabExists(url,tabname) and tabname == TAB_EPISODES:
+    tabname = TAB_CLIPS # In case there are no episodes for a show, get the clips instead
+  elif not tabExists(url,tabname):
+    common.log("Could not find tab "+tabname+" on page. Aborting!")
+    return 
 
   (foundUrl,ajaxurl,lastpage) = parseAjaxUrlAndLastPage(url,tabname)
 
@@ -372,12 +425,15 @@ def parseAjaxUrlAndLastPage(url,tabname):
   container = common.parseDOM(html,
                               "div",
                               attrs = { "class": "[^\"']*[playBoxBody|playBoxAltBody][^\"']*", "data-tabname": tabname })[0]
-  try:
+
+  attrs = { "class": classexp, "data-name": dataname}
+  
+  if elementExists(container,"a", attrs):
     ajaxurl = common.parseDOM(container,
-                                "a",
-                                attrs = { "class": classexp, "data-name": dataname },
-                                ret = "data-baseurl")[0]
-  except:
+                              "a",
+                              attrs = attrs,
+                              ret = "data-baseurl")[0]
+  else:
     return (False,"","")
 
   lastpage = common.parseDOM(container,
@@ -439,8 +495,7 @@ def createDirItem(article,mode):
 
   (title,url,thumbnail,info) = article
 
-  if settings.getSetting("hidesignlanguage") == "false" or \
-     title.lower().endswith("teckentolkad") == False:
+  if (not HIDE_SIGN_LANGUAGE) or title.lower().endswith("teckentolkad") == False:
 
     params = {}
     params["mode"] = mode
@@ -635,7 +690,7 @@ def startVideo(url):
 
       player.setSubtitles(subtitle)
 
-      if settings.getSetting("showsubtitles") == "false":
+      if not SHOW_SUBTITLES:
         player.showSubtitles(False)
   else:
     dialog = xbmcgui.Dialog()
@@ -797,7 +852,7 @@ if not index:
 if not mode:
   viewStart()
 elif mode == MODE_A_TO_O:
-  if settings.getSetting("alpha") == "true":
+  if USE_ALPHA_CATEGORIES:
     viewAlphaDirectories()
   else:
     viewAtoO()
@@ -821,10 +876,10 @@ elif mode == MODE_RECOMMENDED:
   viewLatest(mode,page,index)
 elif mode == MODE_SEARCH:
   viewSearch()
-elif mode == MODE_SEARCH_TITLES or \
-     mode == MODE_SEARCH_EPISODES or \
-     mode == MODE_SEARCH_CLIPS:
-  viewSearchResults(url,mode,page,index)
+elif mode == MODE_VIEW_TITLES or \
+     mode == MODE_VIEW_EPISODES or \
+     mode == MODE_VIEW_CLIPS:
+  viewPageResults(url,mode,page,index)
 elif mode == MODE_BESTOF_CATEGORIES:
   viewBestOfCategories()
 elif mode == MODE_BESTOF_CATEGORY:

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -21,6 +21,7 @@
   <string id="30503">Number of programs per page</string>
   <string id="30504">Hide sign language interpreted programs</string>
   <string id="30505">Don't use avc1.77.30 streams</string>
+  <string id="30506">Show both clips and episodes for programs</string>
   <string id="40001">General</string>
   <string id="40002">Advanced</string>
 </strings>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -21,6 +21,7 @@
   <string id="30503">Antal program per sida</string>
   <string id="30504">Dölj teckentolkade program</string>
   <string id="30505">Använd inte avc1.77.30 videoströmmar</string>
+  <string id="30506">Visa både klipp och avsnitt för program</string>
   <string id="40001">Allmänt</string>
   <string id="40002">Avancerat</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,7 @@
   <category label="40001">
     <setting id="diritems" type="slider" label="30503" default="20" range="20,10,100" option="int" />
     <setting id="alpha" type="bool" label="30502" default="false" />
+    <setting id="fullparse" type="bool" label="30506" default="false" />
     <setting id="hidesignlanguage" type="bool" label="30504" default="false" />
     <setting id="showsubtitles" type="bool" label="30501" default="false" />
     <setting id="debug" type="bool" label="30500" default="false" />


### PR DESCRIPTION
This commit introduces two options to the user:
- Only show episodes in program listing, but fallback to clips if no episodes are available.
- Or, group clips and episodes into two different sub-categories

The user can toggle the behavior in the add-on settings.

Without this commit, shows that have now episodes (but clips) will crash the script.
