### PR TITLE
Refactor "startVideo"

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -26,6 +26,6 @@
   <string id="30506">Show both clips and episodes for programs</string>
   <string id="30507">Set bandwidth manually</string>
   <string id="30508">Bandwidth</string>
-  <string id="40001">General</string>
-  <string id="40002">Advanced</string>
+  <string id="30601">General</string>
+  <string id="30602">Advanced</string>
 </strings>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -26,6 +26,6 @@
   <string id="30506">Visa både klipp och avsnitt för program</string>
   <string id="30507">Ställ in bandbredd manuellt</string>
   <string id="30508">Bandbredd</string>
-  <string id="40001">Allmänt</string>
-  <string id="40002">Avancerat</string>
+  <string id="30601">Allmänt</string>
+  <string id="30602">Avancerat</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-  <category label="40001">
+  <category label="30601">
     <setting id="diritems" type="slider" label="30503" default="20" range="20,10,100" option="int" />
     <setting id="alpha" type="bool" label="30502" default="false" />
     <setting id="fullparse" type="bool" label="30506" default="false" />
@@ -8,7 +8,7 @@
     <setting id="showsubtitles" type="bool" label="30501" default="false" />
     <setting id="debug" type="bool" label="30500" default="false" />
   </category>
-  <category label="40002">
+  <category label="30602">
     <setting id="hlsstrip" type="bool" label="30505" default="false" />
     <setting id="bwselect" type="bool" label="30507" default="false" enable="eq(-1,false)" />
     <setting id="bandwidth" type="select" label="30508" default="2500" values="300|500|900|1600|2500" enable="eq(-1,true) + eq(-2,false)" />


### PR DESCRIPTION
"startVideo" is now split into "getVideoUrl", "getSubtitle" and "startVideo" to make this section of the code more readable.
Furthermore, "getVideoUrl" now passes along an error message if no stream is found so that we can give the user better error information.
