### PR TITLE
Show proper dialog for unavailble streams

### DIFF
--- a/default.py
+++ b/default.py
@@ -294,10 +294,7 @@ def startVideo(url):
   else:
     # No video URL was found
     dialog = xbmcgui.Dialog()
-    if not errormsg:
-      dialog.ok("SVT Play", localize(30100))
-    else:
-      dialog.ok("SVT Play", errormsg)
+    dialog.ok("SVT Play", localize(30100))
 
 
 def addDirectoryItem(title, params, thumbnail = None, folder = True, live = False, info = None):


### PR DESCRIPTION
Without this the following exception occurs.
 Error Type: <type 'exceptions.NameError'>
 Error Contents: global name 'errormsg' is not defined
 Traceback (most recent call last):
   File "/storage/.xbmc/addons/plugin.video.svtplay/default.py", line 369, in <module>
     startVideo(ARG_URL)
   File "/storage/.xbmc/addons/plugin.video.svtplay/default.py", line 297, in startVideo
     if not errormsg:
 NameError: global name 'errormsg' is not defined
