### PR TITLE
Fix to remove genres from "Program A-Ö"

### DIFF
--- a/default.py
+++ b/default.py
@@ -22,6 +22,7 @@ MODE_PROGRAM = "pr"
 MODE_CLIPS = "clips"
 MODE_LIVE_PROGRAMS = "live-channels"
 MODE_LATEST = "ep"
+MODE_LATEST_NEWS = 'news'
 MODE_POPULAR = "popular"
 MODE_LAST_CHANCE = "last-chance"
 MODE_VIDEO = "video"
@@ -56,6 +57,7 @@ def viewStart():
 
   addDirectoryItem(localize(30009), { "mode": MODE_POPULAR })
   addDirectoryItem(localize(30003), { "mode": MODE_LATEST })
+  addDirectoryItem(localize(30004), { "mode": MODE_LATEST_NEWS })
   addDirectoryItem(localize(30010), { "mode": MODE_LAST_CHANCE })
   addDirectoryItem(localize(30002), { "mode": MODE_LIVE_PROGRAMS })
   addDirectoryItem(localize(30008), { "mode": MODE_CHANNELS })
@@ -125,6 +127,13 @@ def viewPopular():
 
 def viewLatestVideos():
   articles = svt.getLatestVideos()
+  if not articles:
+    return
+  for article in articles:
+    createDirItem(article, MODE_VIDEO)
+
+def viewLatestNews():
+  articles = svt.getLatestNews()
   if not articles:
     return
   for article in articles:
@@ -366,6 +375,8 @@ elif ARG_MODE == MODE_VIDEO:
   startVideo(ARG_URL)
 elif ARG_MODE == MODE_LATEST:
   viewLatestVideos()
+elif ARG_MODE == MODE_LATEST_NEWS:
+  viewLatestNews()
 elif ARG_MODE == MODE_POPULAR:
   viewPopular()
 elif ARG_MODE == MODE_LAST_CHANCE:

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -43,7 +43,7 @@ def convertChar(char):
 
 def convertDuration(duration):
   """
-  Converts SVT's duration format to XBMC friendly format (minutes).
+  Converts SVT's duration format to XBMC friendly format (seconds).
 
   SVT has the following format on their duration strings:
   1 h 30 min
@@ -58,13 +58,13 @@ def convertDuration(duration):
   dseconds = 0
 
   if match.group(1):
-    dhours = int(match.group(2)) * 60
+    dhours = int(match.group(2)) * 3600
 
   if match.group(3):
-    dminutes = int(match.group(4))
+    dminutes = int(match.group(4)) * 60
 
   if match.group(5):
-    dseconds = int(match.group(6)) / 60
+    dseconds = int(match.group(6))
 
   return str(dhours + dminutes + dseconds)
 

--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -10,6 +10,7 @@ URL_A_TO_O = "/program"
 URL_TO_SEARCH = "/sok?q="
 URL_TO_OA = "/kategorier/oppetarkiv"
 URL_TO_CHANNELS = "/kanaler"
+URL_TO_NEWS = "/nyheter"
 
 JSON_SUFFIX = "?output=json"
 
@@ -24,6 +25,12 @@ SEARCH_LIST_TITLES = "[^\"']*playJs-search-titles[^\"']*"
 SEARCH_LIST_EPISODES = "[^\"']*playJs-search-episodes[^\"']*"
 SEARCH_LIST_CLIPS = "[^\"']*playJs-search-clips[^\"']*"
 
+def getLatestNews():
+  """
+  Returns a list of latest news.
+  """
+  sliderId = "playJs-latest"
+  return getArticles(sliderId, URL_TO_NEWS)
 
 def getAtoO():
   """

--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -39,9 +39,10 @@ def getAtoO():
 
   for index, text in enumerate(texts):
     program = {}
-    program["title"] = common.replaceHTMLCodes(text)
-    program["url"] = hrefs[index]
-    programs.append(program)
+    if (hrefs[index][0:7] != u'/genre/'):
+        program["title"] = common.replaceHTMLCodes(text)
+        program["url"] = hrefs[index]
+        programs.append(program)
 
   return programs
 


### PR DESCRIPTION
http://www.svtplay.se/program lists genres at the top, and then the programs. This causes the list to be filled with a lot of genres at the top, followed by the programs listed A-Ö. This fix removes any url the that contains "/genre/".
Before:
![before](https://cloud.githubusercontent.com/assets/5602677/9135863/fbae099e-3d11-11e5-8943-6b92488ef4df.png)
After:
![after](https://cloud.githubusercontent.com/assets/5602677/9135878/14047e38-3d12-11e5-81f2-3e6b7959630f.png)
