### PR TITLE
Duration fix

### DIFF
--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -43,7 +43,7 @@ def convertChar(char):
 
 def convertDuration(duration):
   """
-  Converts SVT's duration format to XBMC friendly format (minutes).
+  Converts SVT's duration format to XBMC friendly format (seconds).
 
   SVT has the following format on their duration strings:
   1 h 30 min
@@ -58,13 +58,13 @@ def convertDuration(duration):
   dseconds = 0
 
   if match.group(1):
-    dhours = int(match.group(2)) * 60
+    dhours = int(match.group(2)) * 3600
 
   if match.group(3):
-    dminutes = int(match.group(4))
+    dminutes = int(match.group(4)) * 60
 
   if match.group(5):
-    dseconds = int(match.group(6)) / 60
+    dseconds = int(match.group(6))
 
   return str(dhours + dminutes + dseconds)
 

--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -39,9 +39,10 @@ def getAtoO():
 
   for index, text in enumerate(texts):
     program = {}
-    program["title"] = common.replaceHTMLCodes(text)
-    program["url"] = hrefs[index]
-    programs.append(program)
+    if (hrefs[index][0:7] != u'/genre/'):
+        program["title"] = common.replaceHTMLCodes(text)
+        program["url"] = hrefs[index]
+        programs.append(program)
 
   return programs
 


### PR DESCRIPTION
The duration of an item is now consistent with the rest of Kodi.

Library shows the duration hh:mm:ss, as shown here:
![library](https://cloud.githubusercontent.com/assets/5602677/9309380/8042c4e8-4509-11e5-96af-e8d0d3a14af2.png)
After fix:
![image](https://cloud.githubusercontent.com/assets/5602677/9309403/ae6c4cd6-4509-11e5-8b4d-3b68845bd08e.png)
