### PR TITLE
Duration consistent with library

### DIFF
--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -43,7 +43,7 @@ def convertChar(char):
 
 def convertDuration(duration):
   """
-  Converts SVT's duration format to XBMC friendly format (minutes).
+  Converts SVT's duration format to XBMC friendly format (seconds).
 
   SVT has the following format on their duration strings:
   1 h 30 min
@@ -58,13 +58,13 @@ def convertDuration(duration):
   dseconds = 0
 
   if match.group(1):
-    dhours = int(match.group(2)) * 60
+    dhours = int(match.group(2)) * 3600
 
   if match.group(3):
-    dminutes = int(match.group(4))
+    dminutes = int(match.group(4)) * 60
 
   if match.group(5):
-    dseconds = int(match.group(6)) / 60
+    dseconds = int(match.group(6))
 
   return str(dhours + dminutes + dseconds)
 


### PR DESCRIPTION
The duration of an item is now consistent with the rest of Kodi.

Library shows the duration hh:mm:ss, as shown here:
![library](https://cloud.githubusercontent.com/assets/5602677/9309789/35add474-450c-11e5-8d9a-e86fbd3f0db9.png)

After fix:
![image](https://cloud.githubusercontent.com/assets/5602677/9309841/6f72d010-450c-11e5-95d3-8ffa1a6a19e5.png)
