### PR TITLE
Fix getItems for get_popular and get_last_chance

### DIFF
--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -397,7 +397,7 @@ def getProgramItems(section_name, url=None):
 def getItems(section_name, page):
   if not page:
     page = 1
-  url = BASE_URL+API_URL+section_name+"_page"+";sida="+str(page)
+  url = BASE_URL+API_URL+section_name+"_page?page="+str(page)
   r = requests.get(url)
   if r.status_code != 200:
     common.log("Did not get any response for: "+url)


### PR DESCRIPTION
get_last_chance and get_popular does not return a list of valid items.

This fix will pass page as get parameter `"?page="+str(page)` within the url.

You can run the test to reproduce the issue and validate my fix.
