### PR TITLE
Fix broken playback on old Kodi versions/devices

### DIFF
--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -297,6 +297,8 @@ def getAltUrl(video_url):
   query = urlparse.parse_qs(o.query)
   try:
     alt = query["alt"][0]
+    ufile = urllib.urlopen(alt)
+    alt = ufile.geturl()
   except KeyError, e:
     alt = None
   return alt


### PR DESCRIPTION
Some devices running older versions of Kodi does not properly
follow redirects and are unable to playback the video when the
video url originates from the "alt" url parameter. This fix should
resolve the alt url prior to sending it to the video player.