### PR TITLE
Some programs fails to play

### DIFF
--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -315,8 +315,8 @@ def getVideoJSON(video_url):
       video_id = video_url.replace("video/", "")
     # ID should end with "A" for primary video source.
     # That is, not texted or sign interpreted.
-    if not video_id.endswith("A"):
-      video_id = video_id + "A"
+    #if not video_id.endswith("A"):
+    #  video_id = video_id + "A"
   elif "klipp" in video_url:
     video_id = video_url.replace("klipp/", "")
   return __get_video_json_for_video_id(video_id)
@@ -333,15 +333,15 @@ def getItems(section_name, page):
 
   returned_items = []
   for video in json_data["data"]:
-    is_program = video.get("hasEpisodes", False)
+    is_program = video.get("episodic", False)
     item = {}
     item["title"] = video["programTitle"]
-    if is_program:
-      item["url"] = video["contentUrl"]
-      item["type"] = "program"
-    else:
-      item["url"] = "video/" + str(video["id"])
-      item["type"] = "video"
+    #if is_program:
+    #  item["url"] = video["contentUrl"]
+    #  item["type"] = "program"
+    #else:
+    item["url"] = "video/" + str(video["versions"][0]["id"])
+    item["type"] = "video"
     item["thumbnail"] = helper.prepareThumb(video.get("thumbnail", ""), baseUrl=BASE_URL)
     info = {}
     info["title"] = item["title"]


### PR DESCRIPTION
Hello! i've noticed that some items have started to fail lately so i did some digging.

One program that fails is "Gorbatjovs sista varning". Currently the add-on will try to play `video/1382532-001A` which in the end fetches `http://api.svt.se/videoplayer-api/video/1382532-001A` that returns `{"message":"To many retry attempts to video API","status":404}` (the message seems a bit weird, i get the same from other hosts).

Looking at what svtplay.se plays i see that is plays `video/1382532-001C` which it seems to get from the "versions" array:
```sh
curl "https://www.svtplay.se/api/latest?page=2&excludedTagsString=lokalt" | jq '.data[] | .title,.versions' | grep -A 10 Gorb
```
```sh
"Gorbatjovs sista varning"
[
  {
    "id": "1382532-001C",
    "articleId": 16366646,
    "contentUrl": "/video/16366646/gorbatjovs-sista-varning/dokument-utifran-gorbatjovs-sista-varning-avsnitt-1",
    "accessService": "none"
  }
]
"Nobel 2017: Fredspriskonserten i Oslo"
[
```
Some other version array with multiple items:
```json
"Avsnitt 8"
[
  {
    "id": "1377784-008A",
    "articleId": 16240046,
    "contentUrl": "/video/16240046/forsta-dejten/forsta-dejten-sasong-1-avsnitt-8",
    "accessService": "none"
  },
  {
    "id": "1377784-008S",
    "articleId": 16240066,
    "contentUrl": "/video/16240066/forsta-dejten/forsta-dejten-sasong-1-avsnitt-8",
    "accessService": "audioDescription"
  },
  {
    "id": "1377784-008T",
    "articleId": 16240050,
    "contentUrl": "/video/16240050/forsta-dejten/forsta-dejten-sasong-1-avsnitt-8",
    "accessService": "signInterpretation"
  }
]
```

Can the add-on relay totally on id:s in the versions array now? i see that there are lots of small id/url tweaks currently in the code.