### PR TITLE
Minor improvements

### DIFF
--- a/default.py
+++ b/default.py
@@ -25,6 +25,7 @@ addon = xbmcaddon.Addon("plugin.video.svtplay")
 xbmcplugin.setContent(PLUGIN_HANDLE, "tvshows")
 xbmcplugin.addSortMethod(PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_UNSORTED)
 xbmcplugin.addSortMethod(PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
+xbmcplugin.addSortMethod(PLUGIN_HANDLE, xbmcplugin.SORT_METHOD_DATEADDED)
 
 DEFAULT_FANART = os.path.join(
   xbmc.translatePath(addon.getAddonInfo("path") + "/resources/images/"),

--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -340,7 +340,7 @@ def getItems(section_name, page):
 
 def __create_item_from_json(json_item):
   item = {}
-  item["title"] = json_item["programTitle"]
+  item["title"] = json_item["title"]
   try:
     item["title"] = "{title} [COLOR gray](S{season}E{episode})[/COLOR]".format(title=item["title"], season=str(json_item["season"]), episode=str(json_item["episodeNumber"]))
   except KeyError:

--- a/resources/lib/svt.py
+++ b/resources/lib/svt.py
@@ -355,6 +355,7 @@ def __create_item_from_json(json_item):
   info["tagline"] = json_item.get("shortDescription", "")
   info["season"] = json_item.get("season", "")
   info["episode"] = json_item.get("episodeNumber", "")
+  info["dateadded"] = json_item.get("validFrom","2009-04-05 23:16:04")[:19]
   info["playcount"] = 0
   item["onlyAvailableInSweden"] = json_item.get("onlyAvailableInSweden", False)
   item["inappropriateForChildren"] = json_item.get("inappropriateForChildren", False)


### PR DESCRIPTION
1) As before use the title of the program rather than the program title.  
Thus when you are in the category rapport the shows will say e.g. sep 20 18:00, rather than a list full of Rapport...
2) Added the option to sort the episodes by the date added. Making it easier to find a specific show.
Note that the issue with time zone doesn't apply here since it's only used for sorting.

I did only a few tests for which it seems fine.
Merge it or only consider it as a suggestion of improvement =)