### PR TITLE
Prefix item title with season title if condtions met

### DIFF
--- a/resources/lib/api/graphql.py
+++ b/resources/lib/api/graphql.py
@@ -114,7 +114,7 @@ class GraphQL:
       for item in content["items"]:
         item = item["item"]
         season_title = ""
-        if content["type"] == "Season" and content["name"]:
+        if content["type"] == "Season" and content["name"] and item["positionInSeason"]:
           season_title = content["name"]
         title = item["name"]
         video_id = item["urls"]["svtplay"]

--- a/resources/lib/api/graphql.py
+++ b/resources/lib/api/graphql.py
@@ -158,7 +158,6 @@ class GraphQL:
       info = {
         "duration": item["duration"]
       }
-      season_title = ""
       video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart)
       latest_items.append(video_item)
     return latest_items
@@ -265,7 +264,6 @@ class GraphQL:
     for item in selection["items"]:
       image_id = item["images"]["cleanWide"]["id"]
       image_changed = item["images"]["cleanWide"]["changed"]
-      logging.log("item: {}".format(item))
       title = "{show} - {episode}".format(show=item["heading"], episode=item["subHeading"])
       item = item["item"]
       video_id = item["urls"]["svtplay"]

--- a/resources/lib/api/graphql.py
+++ b/resources/lib/api/graphql.py
@@ -113,6 +113,9 @@ class GraphQL:
         continue
       for item in content["items"]:
         item = item["item"]
+        season_title = ""
+        if content["type"] == "Season" and content["name"]:
+          season_title = content["name"]
         title = item["name"]
         video_id = item["urls"]["svtplay"]
         geo_restricted = item["restrictions"]["onlyAvailableInSweden"]
@@ -122,7 +125,7 @@ class GraphQL:
           "plot" : item["longDescription"],
           "duration" : item.get("duration", 0)
         }
-        video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart)
+        video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart, season_title)
         video_items.append(video_item)
     return video_items
 
@@ -155,6 +158,7 @@ class GraphQL:
       info = {
         "duration": item["duration"]
       }
+      season_title = ""
       video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart)
       latest_items.append(video_item)
     return latest_items
@@ -261,6 +265,7 @@ class GraphQL:
     for item in selection["items"]:
       image_id = item["images"]["cleanWide"]["id"]
       image_changed = item["images"]["cleanWide"]["changed"]
+      logging.log("item: {}".format(item))
       title = "{show} - {episode}".format(show=item["heading"], episode=item["subHeading"])
       item = item["item"]
       video_id = item["urls"]["svtplay"]

--- a/resources/lib/listing/listitem.py
+++ b/resources/lib/listing/listitem.py
@@ -9,7 +9,7 @@ class PlayItem(object):
     VIDEO_ITEM = "video"
     SHOW_ITEM = "show"
 
-    def __init__(self, title, id, item_type, thumbnail="", geo_restricted=False, info={}, fanart=""):
+    def __init__(self, title, id, item_type, thumbnail="", geo_restricted=False, info={}, fanart="", season_title=""):
         if not title:
             raise ValueError("Title is missing!")
         if not id:
@@ -23,6 +23,7 @@ class PlayItem(object):
         self.item_type = item_type
         self.info = info
         self.fanart = fanart
+        self.season_title = season_title
 
     def __str__(self):
         return "{title:" + self.title + ", id:" + self.id + "}"
@@ -34,8 +35,8 @@ class VideoItem(PlayItem):
     """
     A video list item.
     """
-    def __init__(self, title, video_id, thumbnail, geo_restricted, info={}, fanart=""):
-        super(VideoItem, self).__init__(title, video_id, PlayItem.VIDEO_ITEM, thumbnail, geo_restricted, info, fanart)
+    def __init__(self, title, video_id, thumbnail, geo_restricted, info={}, fanart="", season_title=""):
+        super(VideoItem, self).__init__(title, video_id, PlayItem.VIDEO_ITEM, thumbnail, geo_restricted, info, fanart, season_title)
 
 class ShowItem(PlayItem):
     """

--- a/resources/lib/listing/listitem.py
+++ b/resources/lib/listing/listitem.py
@@ -9,7 +9,7 @@ class PlayItem(object):
     VIDEO_ITEM = "video"
     SHOW_ITEM = "show"
 
-    def __init__(self, title, id, item_type, thumbnail="", geo_restricted=False, info={}, fanart="", season_title=""):
+    def __init__(self, title, id, item_type, thumbnail="", geo_restricted=False, info={}, fanart=""):
         if not title:
             raise ValueError("Title is missing!")
         if not id:
@@ -23,7 +23,6 @@ class PlayItem(object):
         self.item_type = item_type
         self.info = info
         self.fanart = fanart
-        self.season_title = season_title
 
     def __str__(self):
         return "{title:" + self.title + ", id:" + self.id + "}"
@@ -36,7 +35,8 @@ class VideoItem(PlayItem):
     A video list item.
     """
     def __init__(self, title, video_id, thumbnail, geo_restricted, info={}, fanart="", season_title=""):
-        super(VideoItem, self).__init__(title, video_id, PlayItem.VIDEO_ITEM, thumbnail, geo_restricted, info, fanart, season_title)
+        self.season_title = season_title
+        super(VideoItem, self).__init__(title, video_id, PlayItem.VIDEO_ITEM, thumbnail, geo_restricted, info, fanart)
 
 class ShowItem(PlayItem):
     """

--- a/resources/lib/svtplay.py
+++ b/resources/lib/svtplay.py
@@ -269,7 +269,7 @@ class SvtPlay:
         info = play_item.info
         fanart = play_item.fanart if play_item.item_type == PlayItem.VIDEO_ITEM else ""
         title = play_item.title
-        if play_item.season_title:
+        if play_item.item_type == PlayItem.VIDEO_ITEM and play_item.season_title:
             title = "{season} - {episode}".format(season=play_item.season_title, episode=play_item.title)
         self.__add_directory_item(title, params, play_item.thumbnail, folder, False, info, fanart)
 

--- a/resources/lib/svtplay.py
+++ b/resources/lib/svtplay.py
@@ -268,7 +268,10 @@ class SvtPlay:
             return
         info = play_item.info
         fanart = play_item.fanart if play_item.item_type == PlayItem.VIDEO_ITEM else ""
-        self.__add_directory_item(play_item.title, params, play_item.thumbnail, folder, False, info, fanart)
+        title = play_item.title
+        if play_item.season_title:
+            title = "{season} - {episode}".format(season=play_item.season_title, episode=play_item.title)
+        self.__add_directory_item(title, params, play_item.thumbnail, folder, False, info, fanart)
 
     def __is_geo_restricted(self, play_item):
         return play_item.geo_restricted and \


### PR DESCRIPTION
Some samples of the before - after outcome.
The greatest benefit is displayed in the last example, where episodes is displayed from multiple seasons.

**! Note**
`item.positionInSeason` is used to determine if it is any "value" for the end-user to set season title.
For example, for the show **"Greta Gris"**, the season title was simply **"Kortisar"** which made no sense prefixing the episode titles with.

btw, could you please add topic "hacktoberfest"? 🙂 🙏 
_"Maintainers of the repository can add the "hacktoberfest" topic to their repository if they wish to participate."_
https://hacktoberfest.digitalocean.com/

~~I also fixed an issue with episodes roaming around without a show title under Genres, see commit https://github.com/nilzen/xbmc-svtplay/pull/264/commits/ece239c5e917a091e045d459a12210fdd7759451 and screenshots **007 - Before** and **008 - After**.~~

Tests works fine, no changes/additions to tests however.

**001 - Before**
![001-before](https://user-images.githubusercontent.com/6221909/94992341-b88f7580-0589-11eb-8109-0ffd68b9bc47.png)
**002 - After**
![002-after](https://user-images.githubusercontent.com/6221909/94992347-ba593900-0589-11eb-8f9c-75827efd0e8d.png)

**003 - Before**
![003-before](https://user-images.githubusercontent.com/6221909/94992345-b9c0a280-0589-11eb-98c7-f2e045e03a54.png)
**004 - After**
![004-after](https://user-images.githubusercontent.com/6221909/94992346-ba593900-0589-11eb-9661-ddb13e86d5de.png)

**005 - Before**
![005-before](https://user-images.githubusercontent.com/6221909/94992344-b9c0a280-0589-11eb-8efd-d63492583d4e.png)
**006 - After**
![006-after](https://user-images.githubusercontent.com/6221909/94992343-b9280c00-0589-11eb-8a21-fbf6f5860cd9.png)
