### PR TITLE
Fix broken go-to-show button

### DIFF
--- a/resources/lib/api/svt.py
+++ b/resources/lib/api/svt.py
@@ -100,14 +100,16 @@ def __get_video_version(versions):
 def episodeUrlToShowUrl(url):
   """
   Returns the show URL from episode url.
-  Example: "/video/22132986/abel-och-fant/abel-och-fant-sasong-2-kupa-pa-rymmen" > "abel-och-fant"
-
+  Example1: "/video/22132986/abel-och-fant/abel-och-fant-sasong-2-kupa-pa-rymmen" > "abel-och-fant"
+  Example2: "/bluey" > "bluey"
   Returns None for single video items (movies etc)
   """
   new_url = None
   stub_url = url.split("/")
   if len(stub_url) >= 5:
     new_url = stub_url[3]
+  elif len(stub_url) == 2:
+    new_url = stub_url[1]  
   return new_url
 
 def resolveShowJson(json_obj):

--- a/tests/testSvt.py
+++ b/tests/testSvt.py
@@ -47,6 +47,12 @@ class TestSvtModule(unittest.TestCase):
     expected = "some-thing-here"
     self.assertEqual(actual, expected)
 
+  def test_episode_url_to_show_url_2(self):
+    url = "/bluey"
+    actual = svt.episodeUrlToShowUrl(url)
+    expected = "bluey"
+    self.assertEqual(actual, expected)
+
   def test_single_video_url_to_show_url(self):
     url = "/video/22132986/some-thing-here"
     actual = svt.episodeUrlToShowUrl(url)


### PR DESCRIPTION
In "Popular", the "Go to show" context option is missing.