### PR TITLE
Initial formatting support for list items

### DIFF
--- a/resources/lib/api/graphql.py
+++ b/resources/lib/api/graphql.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import,unicode_literals
 import json
 import re
 import requests
+from resources.lib.helper import strip_html_tags
 from resources.lib import logging
 from resources.lib.listing.listitem import VideoItem, ShowItem
 
@@ -312,6 +313,11 @@ class GraphQL:
     return sorted(items, key=lambda item: item.title)
 
   def __create_item(self, title, type_name, item_id, geo_restricted, thumbnail="", info={}, fanart=""):
+    title = strip_html_tags(title)
+
+    for k in info:
+        info[k] = strip_html_tags(info[k])
+
     if self.__is_video(type_name):
       return VideoItem(title, item_id, thumbnail, geo_restricted, info=info, fanart=fanart)
     elif self.__is_show(type_name):

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -36,3 +36,13 @@ def getInputFromKeyboard(heading):
   if keyboard.isConfirmed():
       text = keyboard.getText()
   return text
+
+def strip_html_tags(string):
+    if not string:
+        return string
+
+    try:
+        return re.sub('<[^<]+?>', '', string)
+    except Exception as e:
+        logging.error('An error occured while trying to strip tags from text: "{}". Exception: {}'.format(string, e))
+        return string

--- a/tests/testHelper.py
+++ b/tests/testHelper.py
@@ -15,5 +15,20 @@ class TestHelperModule(unittest.TestCase):
         expected = { "id" : "http://stream.video/ä.m3u8", "mode" : "video"}
         self.assertDictEqual(actual, expected)
 
+    def test_strip_html_tags_with_tags(self):
+        actual = helper.strip_html_tags('<em>Once upon a time</em>')
+        expected = 'Once upon a time'
+        self.assertEqual(actual, expected)
+
+    def test_strip_html_tags_without_tags(self):
+        actual = helper.strip_html_tags('Once upon a time')
+        expected = 'Once upon a time'
+        self.assertEqual(actual, expected)
+
+    def test_strip_html_tags_with_None(self):
+        actual = helper.strip_html_tags(None)
+        expected = None
+        self.assertEqual(actual, expected)
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Have been annoyed by <em> tags (among others) showing up in the titles for the the list items. Therefore this is a tiny small modification to correctly format those titles, an alternative would be to just drop them but I think there are other formatting applied by the data from SVT aswell.